### PR TITLE
Bump MSTest from 3.9.3 to 3.10.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,6 +3,6 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="MSTest" Version="3.9.3" />
+    <PackageVersion Include="MSTest" Version="3.10.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
---
updated-dependencies:
- dependency-name: MSTest dependency-version: 3.10.1 dependency-type: direct:production update-type: version-update:semver-minor ...